### PR TITLE
子线程调用crash问题

### DIFF
--- a/BSBacktraceLogger/BSBacktraceLogger.m
+++ b/BSBacktraceLogger/BSBacktraceLogger.m
@@ -140,7 +140,7 @@ NSString *_bs_backtraceOfThread(thread_t thread) {
         return @"Fail to get frame pointer";
     }
     
-    for(; i < INT_MAX; i++) {
+    for(; i < 50; i++) {
         backtraceBuffer[i] = frame.return_address;
         if(backtraceBuffer[i] == 0 ||
            frame.previous == 0 ||


### PR DESCRIPTION
`//  后台执行：
    dispatch_async(dispatch_get_global_queue(0, 0), ^{
        // something
        for (NSInteger i = 0; i < 10000 ; i ++) {
            [KGPrintThreadSnapshoot bs_backtraceOfAllThread];
        }
    });
`

_bs_backtraceOfThread crash 问题
