### PR TITLE
Fix build issues using Xcode 13 and new build system.

### DIFF
--- a/BsBacktraceLogger.xcodeproj/project.pbxproj
+++ b/BsBacktraceLogger.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		9BD96D1A1D71AA630046048A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9BD96D0E1D71AA630046048A /* LaunchScreen.storyboard */; };
 		9BD96D1B1D71AA630046048A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9BD96D101D71AA630046048A /* Main.storyboard */; };
 		9BD96D1C1D71AA630046048A /* BSBacktraceLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BD96D131D71AA630046048A /* BSBacktraceLogger.m */; };
-		9BD96D1D1D71AA630046048A /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9BD96D141D71AA630046048A /* Info.plist */; };
 		9BD96D1E1D71AA630046048A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BD96D151D71AA630046048A /* main.m */; };
 		9BD96D1F1D71AA630046048A /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BD96D171D71AA630046048A /* ViewController.m */; };
 /* End PBXBuildFile section */
@@ -113,11 +112,12 @@
 					};
 				};
 			};
-			buildConfigurationList = 9BA9BB4A1D6FEA4C00A579CA /* Build configuration list for PBXProject "BSBacktraceLogger" */;
+			buildConfigurationList = 9BA9BB4A1D6FEA4C00A579CA /* Build configuration list for PBXProject "BsBacktraceLogger" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -139,7 +139,6 @@
 				9BD96D191D71AA630046048A /* Assets.xcassets in Resources */,
 				9BD96D1B1D71AA630046048A /* Main.storyboard in Resources */,
 				9BD96D1A1D71AA630046048A /* LaunchScreen.storyboard in Resources */,
-				9BD96D1D1D71AA630046048A /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -290,7 +289,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		9BA9BB4A1D6FEA4C00A579CA /* Build configuration list for PBXProject "BSBacktraceLogger" */ = {
+		9BA9BB4A1D6FEA4C00A579CA /* Build configuration list for PBXProject "BsBacktraceLogger" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				9BA9BB641D6FEA4C00A579CA /* Debug */,


### PR DESCRIPTION
When using Xcode 13, we may encounter the following problem:

```
Showing All Errors Only
Multiple commands produce '/Users/xxx/Library/Developer/Xcode/DerivedData/BsBacktraceLogger-fsnybzqtynwznserpmdtqzimhiux/Build/Products/Debug-iphonesimulator/BSBacktraceLogger.app/Info.plist':
1) Target 'BSBacktraceLogger' (project 'BsBacktraceLogger') has copy command from 'xxx/BSBacktraceLogger/BsBacktraceLogger/Info.plist' to '/Users/xxx/Library/Developer/Xcode/DerivedData/BsBacktraceLogger-fsnybzqtynwznserpmdtqzimhiux/Build/Products/Debug-iphonesimulator/BSBacktraceLogger.app/Info.plist'
2) Target 'BSBacktraceLogger' (project 'BsBacktraceLogger') has process command with output '/Users/xxx/Library/Developer/Xcode/DerivedData/BsBacktraceLogger-fsnybzqtynwznserpmdtqzimhiux/Build/Products/Debug-iphonesimulator/BSBacktraceLogger.app/Info.plist'
```

so we need to delete the Info.plist from the `Copy Bundle Resouces` phase.